### PR TITLE
Add contract address to NFT Trader

### DIFF
--- a/lib/achievements_season2.json
+++ b/lib/achievements_season2.json
@@ -291,7 +291,8 @@
                             "address": [
                                 "0xdbd4264248e2f814838702e0cb3015ac3a7157a1",
                                 "0x912C196A95a9b4009a90F4105328B61477351738",
-                                "0x6e0c74c05045c09ba5c6d6818ea7e13cc7a56c1b"
+                                "0x6e0c74c05045c09ba5c6d6818ea7e13cc7a56c1b",
+                                "0x13d8faF4A690f5AE52E2D2C52938d1167057B9af"
                             ]
                         }
                     },


### PR DESCRIPTION
Adding contract that sends to NFT Trader vault

Example transaction from a trade: https://etherscan.io/tx/0xe8dbb47f13b18f099bc823025a57170c45591bfd2bbaf26019e32e4a0a93d9fe 