### PR TITLE
fix nifty gateway contract interaction

### DIFF
--- a/lib/achievements_season2.json
+++ b/lib/achievements_season2.json
@@ -334,13 +334,10 @@
                     {
                         "name": "Purchase NFT on Nifty Gateway",
                         "points": 30,
-                        "type": "transaction_to_address_count",
+                        "type": "transaction_from_address_count",
                         "params": {
                             "count": 1,
-                            "address": [
-                                "0xe052113bd7d7700d623414a0a4585bcae754e9d5",
-                                "0xd998847806dbbbc5fe3e90063475ceccd242b926"
-                            ]
+                            "address": "0xe052113bd7d7700d623414a0a4585bcae754e9d5"
                         }
                     },
                     {


### PR DESCRIPTION
Change the "to" into a "from" requirement. Also removing the wrongly added contract address.
example tx: https://etherscan.io/tx/0x09194439b2415f17dd0d618b5ca6ac33bef1c26f526d8b49884dc171ad21e637