### PR TITLE
update score for Degen Dogs

### DIFF
--- a/lib/achievements_season2.json
+++ b/lib/achievements_season2.json
@@ -526,7 +526,7 @@
                 "steps": [
                     {
                         "name": "Own 1 Degen Dogs (Polygon)",
-                        "points": 10,
+                        "points": 25,
                         "type": "own_token_by_address",
                         "params": {
                             "count": 1,


### PR DESCRIPTION
As the cost of 1 Degen Dog is 0.05 ETH, the score should be 25 points instead of 10 for the easy/cheap achievements.