### PR TITLE
add support for async art music NFT contract

### DIFF
--- a/lib/achievements_season2.json
+++ b/lib/achievements_season2.json
@@ -354,7 +354,10 @@
                         "type": "transaction_to_address_count",
                         "params": {
                             "count": 1,
-                            "address": "0xb6dAe651468E9593E4581705a09c10A76AC1e0c8"
+                            "address": [
+                                "0xb6dAe651468E9593E4581705a09c10A76AC1e0c8",
+                                "0x71925638B9998Ab631C83873D9eD19ef9B70EcF0"
+                            ]
                         }
                     },
                     {


### PR DESCRIPTION
The async art achievement only had the art token address: https://etherscan.io/address/0xb6dAe651468E9593E4581705a09c10A76AC1e0c8
Support for the music NFT's was missing: https://etherscan.io/address/0x71925638b9998ab631c83873d9ed19ef9b70ecf0