### PR TITLE
remove inactive token

### DIFF
--- a/lib/achievements_season2.json
+++ b/lib/achievements_season2.json
@@ -542,15 +542,6 @@
                         }
                     },
                     {
-                        "name": "Own 1 DogeToken",
-                        "points": 10,
-                        "type": "own_token_by_address",
-                        "params": {
-                            "count": 1,
-                            "address": "0x8b9c35c79af5319c70dd9a3e3850f368822ed64e"
-                        }
-                    },
-                    {
                         "name": "Own 1 The Doge NFT",
                         "points": 10,
                         "type": "own_token_by_address",


### PR DESCRIPTION
Removed dogetoken as it is a binance chain token with no liquidity on Ethereum or Polygon